### PR TITLE
Fix Issue #117

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,7 +44,7 @@ body:
   - type: input
     id: version
     attributes:
-      label: Version of `yojenkins` 
+      label: Version of `yojenkins`
       description: Enter the version you were using
       placeholder: "Example: 0.0.57"
     validations:

--- a/yojenkins/cli/cli_utility.py
+++ b/yojenkins/cli/cli_utility.py
@@ -225,8 +225,6 @@ def log_to_history(decorated_function) -> Callable:
         # Check if history file exists
         history_file_path = os.path.join(os.path.join(Path.home(), CONFIG_DIR_NAME), HISTORY_FILE_NAME)
         if not os.path.isfile(history_file_path):
-            print2(f'Failed to find command history file: "{history_file_path}"')
-            print2('Creating blank command history file ...')
             create_new_history_file(history_file_path)
 
         # Load the history file content

--- a/yojenkins/cli/cli_utility.py
+++ b/yojenkins/cli/cli_utility.py
@@ -23,7 +23,7 @@ from yojenkins.yo_jenkins.auth import Auth
 from yojenkins.yo_jenkins.rest import Rest
 from yojenkins.yo_jenkins.yojenkins import YoJenkins
 
-from yojenkins.utility.utility import iter_data_empty_item_stripper, load_contents_from_local_file, am_i_inside_docker, am_i_bundled, print2  # isort:skip
+from yojenkins.utility.utility import iter_data_empty_item_stripper, load_contents_from_local_file, am_i_inside_docker, am_i_bundled, print2, create_new_history_file  # isort:skip
 
 # Getting the logger reference
 logger = logging.getLogger()
@@ -225,13 +225,9 @@ def log_to_history(decorated_function) -> Callable:
         # Check if history file exists
         history_file_path = os.path.join(os.path.join(Path.home(), CONFIG_DIR_NAME), HISTORY_FILE_NAME)
         if not os.path.isfile(history_file_path):
-            logger.debug(f'Failed to find command history file: "{history_file_path}"')
-            logger.debug('Creating blank command history file ...')
-            try:
-                with open(history_file_path, 'w') as open_file:
-                    json.dump({}, open_file)
-            except Exception as error:
-                logger.debug(f'Failed to create new command history file: {error}')
+            print2(f'Failed to find command history file: "{history_file_path}"')
+            print2('Creating blank command history file ...')
+            create_new_history_file(history_file_path)
 
         # Load the history file content
         file_contents = load_contents_from_local_file(COMMAND_HISTORY_FORMAT, history_file_path)

--- a/yojenkins/utility/utility.py
+++ b/yojenkins/utility/utility.py
@@ -26,6 +26,7 @@ logger = logging.getLogger()
 
 CONFIG_DIR_NAME = ".yojenkins"
 
+
 class TextStyle:
     """Text style definitions"""
     HEADER = '\033[95m'
@@ -1037,11 +1038,13 @@ def get_item_action(item_info: dict, class_type: str) -> List[dict]:
 
 
 def create_new_history_file(file_path: str) -> None:
-    """
-    Create a new blank command history file.
+    """Create a new blank command history file.
 
-    :param file_path: full path to the history file
-    :type file_path: str
+    Args:
+        file_path: Full path to the history file
+
+    Returns:
+        None
     """
     try:
         # Creating configuration directory if it does not exist
@@ -1051,5 +1054,5 @@ def create_new_history_file(file_path: str) -> None:
             os.makedirs(config_dir_abs_path)
         with open(file_path, "w") as open_file:
             json.dump({}, open_file)
-    except Exception:
+    except FileExistsError:
         logger.exception("Failed to create new command history file")

--- a/yojenkins/utility/utility.py
+++ b/yojenkins/utility/utility.py
@@ -24,6 +24,7 @@ from yojenkins.yo_jenkins.jenkins_item_classes import JenkinsItemClasses
 
 logger = logging.getLogger()
 
+CONFIG_DIR_NAME = ".yojenkins"
 
 class TextStyle:
     """Text style definitions"""
@@ -1033,3 +1034,22 @@ def get_item_action(item_info: dict, class_type: str) -> List[dict]:
                 actions_info.append(action)
 
     return actions_info
+
+
+def create_new_history_file(file_path: str) -> None:
+    """
+    Create a new blank command history file.
+
+    :param file_path: full path to the history file
+    :type file_path: str
+    """
+    try:
+        # Creating configuration directory if it does not exist
+        config_dir_abs_path = os.path.join(Path.home(), CONFIG_DIR_NAME)
+        if not os.path.exists(config_dir_abs_path):
+            print2("Configuration directory does not exist. Creating it ...")
+            os.makedirs(config_dir_abs_path)
+        with open(file_path, "w") as open_file:
+            json.dump({}, open_file)
+    except Exception:
+        logger.exception("Failed to create new command history file")

--- a/yojenkins/utility/utility.py
+++ b/yojenkins/utility/utility.py
@@ -1049,10 +1049,18 @@ def create_new_history_file(file_path: str) -> None:
     try:
         # Creating configuration directory if it does not exist
         config_dir_abs_path = os.path.join(Path.home(), CONFIG_DIR_NAME)
+
         if not os.path.exists(config_dir_abs_path):
-            print2("Configuration directory does not exist. Creating it ...")
+            logger.debug("Configuration directory does not exist. Creating it ...")
             os.makedirs(config_dir_abs_path)
+
+        if not os.path.exists(file_path):
+            logger.debug(f'Command history file NOT found: "{file_path}"')
+            logger.debug("Creating a new command history file ...")
         with open(file_path, "w") as open_file:
             json.dump({}, open_file)
-    except FileExistsError:
-        logger.exception("Failed to create new command history file")
+
+    except (FileNotFoundError, IOError, PermissionError) as error:
+        fail_out(f'Failed to create history file ({file_path}). Exception: {error}')
+    except Exception as error:
+        logger.exception(f"Failed to create new command history file. Exception: {error}")

--- a/yojenkins/yo_jenkins/auth.py
+++ b/yojenkins/yo_jenkins/auth.py
@@ -233,6 +233,8 @@ class Auth:
         Returns:
             This is a description of what is returned.
         """
+        config_dir_abs_path = os.path.join(Path.home(), CONFIG_DIR_NAME)
+
         # Checking if credential config file exists
         file_exists, file_path = self._detect_creds_file()
         if file_exists:
@@ -243,7 +245,7 @@ class Auth:
             profiles = utility.load_contents_from_local_file("toml", file_path)
             logger.debug(f'Currently listed profile names: {", ".join(list(profiles.keys()))}')
 
-            print2(f'Credentials profile file found in current user home directory: {file_path}')
+            logger.debug(f'Credentials profile file found in current user home directory: {file_path}')
         else:
             creds_file_abs_path = os.path.join(config_dir_abs_path, CREDS_FILE_NAME)
 
@@ -253,8 +255,8 @@ class Auth:
             # Create new profile from scratch
             profiles = {}
 
-            print2(f'Credentials profile file ({CREDS_FILE_NAME}) NOT found in configuration directory')
-            print2(f'Creating a new credentials file: {creds_file_abs_path} ...')
+            logger.debug(f'Credentials profile file NOT found: "{creds_file_abs_path}"')
+            logger.debug(f'Creating a new credentials file ...')
 
         # Check if user passed authentication info file
         if auth_file:
@@ -318,7 +320,8 @@ class Auth:
                 profiles[setup_profile_name] = setup_profile_info
         else:
             # Prompting user for details
-            print2('Please enter the following information to create your first profile entry:')
+            print2('Please enter the following information to create your first profile entry')
+            print2(f'This information will be stored in "{creds_file_abs_path}"')
             print2('')
             profile_name = input(TextStyle.BOLD + TextStyle.YELLOW + '[ OPTIONAL ] Enter PROFILE NAME (default):  ' +
                                  TextStyle.NORMAL)

--- a/yojenkins/yo_jenkins/auth.py
+++ b/yojenkins/yo_jenkins/auth.py
@@ -233,16 +233,6 @@ class Auth:
         Returns:
             This is a description of what is returned.
         """
-        # Creating configuration directory if it does not exist
-        config_dir_abs_path = os.path.join(Path.home(), CONFIG_DIR_NAME)
-        if not self._detect_config_dir()[0]:
-            logger.debug(f'Creating configuration directory in user home directory: {config_dir_abs_path}')
-            try:
-                os.makedirs(config_dir_abs_path)
-                logger.debug(f'Successfully created configuration directory: {config_dir_abs_path}')
-            except OSError as error:
-                fail_out(f'Failed to create user configuration directory "{config_dir_abs_path}": Exception:{error}')
-
         # Checking if credential config file exists
         file_exists, file_path = self._detect_creds_file()
         if file_exists:


### PR DESCRIPTION
This PR aims to resolve issue #117 by way of checking if config directory exists before creating a new command history file.

## Change Motivation
*(A very brief summary on why you made these changes)*

Because running `yojenkins auth configure` would fall over if config directory was not present and command was being logged to history.

---------------------------------------------
## Describe the Changes Made
*(A very brief summary on what changes you made)*

Create a new utility method for creating a new blank command history file which checks if config directory exists before creating the history file. If config directory does not exists then it is created.


---------------------------------------------
## Change Type
*(Check any that apply)*

- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactoring
- [ ] Documentation
- [ ] Formatting
- [ ] Automation
- [ ] Unit Tests
- [ ] Other



---------------------------------------------
## How Has This Been Tested?
*(Please describe the tests/commands that you ran to verify your changes)*

Tested this locally on Windows 11 by running command reported in the issue and observing that history logging would fall over as config directory was not present. After the fix, user is informed if:
* history file does not exists and needs creating
* config directory does not exists and needs creating


---------------------------------------------
# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
