### PR TITLE
[Feature] `--profile` Option Allows To Pass Profile in JSON Text Format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 """Installation/Packaging Definition for Python Project"""
 
+
 import os
 import sys
 

--- a/yojenkins/cli/cli_auth.py
+++ b/yojenkins/cli/cli_auth.py
@@ -12,6 +12,7 @@ from yojenkins.yo_jenkins import Auth, Rest
 # Getting the logger reference
 logger = logging.getLogger()
 
+
 @log_to_history
 def configure(auth_file: str) -> None:
     """Configure authentication

--- a/yojenkins/cli/cli_auth.py
+++ b/yojenkins/cli/cli_auth.py
@@ -12,7 +12,6 @@ from yojenkins.yo_jenkins import Auth, Rest
 # Getting the logger reference
 logger = logging.getLogger()
 
-
 @log_to_history
 def configure(auth_file: str) -> None:
     """Configure authentication

--- a/yojenkins/cli/cli_decorators.py
+++ b/yojenkins/cli/cli_decorators.py
@@ -6,6 +6,25 @@ from typing import Callable
 import click
 
 
+def auth_options(decorated_function: Callable) -> Callable:
+    """click module options for authentication
+
+    Details: This function is a convenience function to use to add click options
+
+    Args:
+        decorated_function : Function that is decorated
+
+    Returns:
+        Decorated function
+    """
+    @click.option('--token', type=str, required=False, is_flag=False, help='Authentication token to use')
+    @functools.wraps(decorated_function)
+    def wrapper(*args, **kwds):
+        return decorated_function(*args, **kwds)
+
+    return wrapper
+
+
 def format_output(decorated_function: Callable) -> Callable:
     """click module options for formatting the output
 
@@ -73,8 +92,8 @@ def profile(decorated_function: Callable) -> Callable:
     Returns:
         Decorated function
     """
-
     @click.option('--profile', type=str, required=False, is_flag=False, help='Authentication profile for command')
+    @click.option('--token', type=str, required=False, is_flag=False, help='Authentication token to use')
     @functools.wraps(decorated_function)
     def wrapper(*args, **kwds):
         return decorated_function(*args, **kwds)

--- a/yojenkins/cli/cli_decorators.py
+++ b/yojenkins/cli/cli_decorators.py
@@ -6,25 +6,6 @@ from typing import Callable
 import click
 
 
-def auth_options(decorated_function: Callable) -> Callable:
-    """click module options for authentication
-
-    Details: This function is a convenience function to use to add click options
-
-    Args:
-        decorated_function : Function that is decorated
-
-    Returns:
-        Decorated function
-    """
-    @click.option('--token', type=str, required=False, is_flag=False, help='Authentication token to use')
-    @functools.wraps(decorated_function)
-    def wrapper(*args, **kwds):
-        return decorated_function(*args, **kwds)
-
-    return wrapper
-
-
 def format_output(decorated_function: Callable) -> Callable:
     """click module options for formatting the output
 
@@ -92,8 +73,13 @@ def profile(decorated_function: Callable) -> Callable:
     Returns:
         Decorated function
     """
-    @click.option('--profile', type=str, required=False, is_flag=False, help='Authentication profile for command')
-    @click.option('--token', type=str, required=False, is_flag=False, help='Authentication token to use')
+
+    @click.option('--profile',
+                  type=str,
+                  required=False,
+                  is_flag=False,
+                  help='Authentication profile name or profile as JSON text')
+    #  @click.option('--token', type=str, required=False, is_flag=False, help='Authentication token to use')
     @functools.wraps(decorated_function)
     def wrapper(*args, **kwds):
         return decorated_function(*args, **kwds)

--- a/yojenkins/cli/cli_server.py
+++ b/yojenkins/cli/cli_server.py
@@ -13,9 +13,8 @@ from yojenkins.docker_container import DockerJenkinsServer
 from yojenkins.utility.utility import (
     fail_out,
     failures_out,
-    get_project_dir,
-    get_resource_path,
     print2,
+    translate_kwargs
 )
 from yojenkins.yo_jenkins import Auth, YoJenkins
 
@@ -27,19 +26,16 @@ CONFIG_DIR_NAME = '.yojenkins'
 
 
 @log_to_history
-def info(opt_pretty: bool, opt_yaml: bool, opt_xml: bool, opt_toml: bool, profile: str) -> None:
-    """TODO Docstring
+def info(profile: str, token: str, **kwargs) -> None:
+    """Get the server information
 
-    Details: TODO
+    Details: Targeting the server that is specified in the selected profile
 
     Args:
         TODO
-
-    Returns:
-        TODO
     """
     data = cu.config_yo_jenkins(profile).server.info()
-    cu.standard_out(data, opt_pretty, opt_yaml, opt_xml, opt_toml)
+    cu.standard_out(data, **translate_kwargs(kwargs))
 
 
 @log_to_history

--- a/yojenkins/cli/cli_server.py
+++ b/yojenkins/cli/cli_server.py
@@ -10,12 +10,7 @@ import click
 from yojenkins.cli import cli_utility as cu
 from yojenkins.cli.cli_utility import log_to_history
 from yojenkins.docker_container import DockerJenkinsServer
-from yojenkins.utility.utility import (
-    fail_out,
-    failures_out,
-    print2,
-    translate_kwargs
-)
+from yojenkins.utility.utility import fail_out, failures_out, print2, translate_kwargs
 from yojenkins.yo_jenkins import Auth, YoJenkins
 
 # Getting the logger reference
@@ -26,7 +21,7 @@ CONFIG_DIR_NAME = '.yojenkins'
 
 
 @log_to_history
-def info(profile: str, token: str, **kwargs) -> None:
+def info(profile: str, **kwargs) -> None:
     """Get the server information
 
     Details: Targeting the server that is specified in the selected profile

--- a/yojenkins/cli/cli_utility.py
+++ b/yojenkins/cli/cli_utility.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from inspect import getfullargspec
 from pathlib import Path
 from shlex import quote
-from typing import Callable
+from typing import Callable, Dict
 
 import click
 import toml
@@ -85,13 +85,15 @@ def platform_information() -> None:
 
 
 def config_yo_jenkins(profile: str) -> YoJenkins:
-    """TODO Docstring
+    """Initialize/Prepare YoJenkins object using the appropriate
+    authentication information
+
 
     Args:
-        TODO
+        profile: Name of the yojenkins authentication profile
 
     Returns:
-        TODO
+        Initialized YoJenkins object
     """
     auth = Auth(Rest())
 
@@ -108,17 +110,15 @@ def config_yo_jenkins(profile: str) -> YoJenkins:
     return YoJenkins(auth)
 
 
-def standard_out(data: dict,
+def standard_out(data: Dict,
                  opt_pretty: bool = False,
                  opt_yaml: bool = False,
                  opt_xml: bool = False,
                  opt_toml: bool = False) -> None:
-    """TODO Docstring
+    """Outputting the resulting data to the console.
+    This funciton handles a variety of output formats.
 
     Args:
-        TODO
-
-    Returns:
         TODO
     """
     # Strip away any empty items in the iterable data
@@ -213,13 +213,16 @@ def log_to_history(decorated_function) -> Callable:
 
     def wrapper(*args, **kwargs) -> None:
         # Get the profile name for the command
-        if arg_index >= 0:
+        if 'profile' in kwargs:
+            profile_name = kwargs['profile']
+        elif arg_index >= 0:
             profile_name = args[arg_index]
         else:
-            # NOTE: If no profile is used by the decorated function, use the default profile name
+            # If no profile is used by the decorated function, use the default profile name
             profile_name = DEFAULT_PROFILE_NAME
+
         if profile_name is None:
-            # NOTE: If function has profile argument, but none was passed, use the default profile name
+            # If function has profile argument, but none was passed, use the default profile name
             profile_name = DEFAULT_PROFILE_NAME
 
         # Check if history file exists

--- a/yojenkins/cli_sub_commands/server.py
+++ b/yojenkins/cli_sub_commands/server.py
@@ -7,6 +7,7 @@ from yojenkins.__main__ import server
 from yojenkins.cli import cli_decorators, cli_server
 from yojenkins.cli.cli_utility import set_debug_log_level
 
+
 @server.command(short_help='\tServer information')
 @cli_decorators.debug
 @cli_decorators.format_output

--- a/yojenkins/cli_sub_commands/server.py
+++ b/yojenkins/cli_sub_commands/server.py
@@ -7,15 +7,16 @@ from yojenkins.__main__ import server
 from yojenkins.cli import cli_decorators, cli_server
 from yojenkins.cli.cli_utility import set_debug_log_level
 
-
 @server.command(short_help='\tServer information')
 @cli_decorators.debug
 @cli_decorators.format_output
 @cli_decorators.profile
-def info(debug, pretty, yaml, toml, xml, profile):
+#  def info(debug, pretty, yaml, toml, xml, profile, token):
+def info(debug, **kwargs):
     """Server information"""
     set_debug_log_level(debug)
-    cli_server.info(pretty, yaml, xml, toml, profile)
+    #  cli_server.info(pretty, yaml, xml, toml, profile, token)
+    cli_server.info(**kwargs)
 
 
 @server.command(short_help='\tShow all people/users on server')

--- a/yojenkins/utility/utility.py
+++ b/yojenkins/utility/utility.py
@@ -9,7 +9,7 @@ import sysconfig
 import webbrowser
 from pathlib import Path
 from string import Template
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Tuple, Set, Union
 from urllib.parse import urljoin, urlparse
 
 import requests
@@ -19,13 +19,20 @@ import yaml
 from click import echo, style
 from urllib3.util import parse_url
 
+from typing import Dict, Any
+
 from yojenkins import __version__
 from yojenkins.yo_jenkins.jenkins_item_classes import JenkinsItemClasses
 
 logger = logging.getLogger()
 
 CONFIG_DIR_NAME = ".yojenkins"
-
+KWARG_TRANSLATE_MAP = {
+    'pretty': 'opt_pretty',
+    'yaml': 'opt_yaml',
+    'xml': 'opt_xml',
+    'toml': 'opt_toml',
+}
 
 class TextStyle:
     """Text style definitions"""
@@ -39,6 +46,26 @@ class TextStyle:
     UNDERLINE = '\033[4m'
     NORMAL = '\033[0m'
 
+def translate_kwargs(original_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Rename the key names of the provided kwargs based on
+    a set of translation rules.
+
+    Details: This is primarirly used if kwarg keys are named like
+             a module or python native object.
+
+    Args:
+        original_kwargs: Key-value data to be updated
+
+    Returns:
+        Updated kwargs
+    """
+    new_kwargs = {}
+    for key, value in original_kwargs.items():
+        if key in list(KWARG_TRANSLATE_MAP.keys()):
+            new_kwargs[KWARG_TRANSLATE_MAP[key]] = value
+        else:
+            new_kwargs[key] = value
+    return new_kwargs
 
 def print2(message: str, bold: bool = False, color: str = 'reset') -> None:
     """Print a message to the console using click
@@ -238,7 +265,7 @@ def append_lines_to_file(filepath: str, lines_to_append: List[str], location: st
     return True
 
 
-def is_list_items_in_dict(list_items: list, dict_to_check: dict) -> int:
+def is_list_items_in_dict(list_items: list, dict_to_check: dict) -> Union[int, None]:
     """Return index of ANY matched item in the passed list
 
     Args:
@@ -254,7 +281,7 @@ def is_list_items_in_dict(list_items: list, dict_to_check: dict) -> int:
     return None
 
 
-def iter_data_empty_item_stripper(iter_data):
+def iter_data_empty_item_stripper(iter_data: Union[Dict, List, Set, Tuple]) -> Union[Dict, List, Set, Tuple]:
     """Removes any empty data from a nested or un-nested iter item
 
     Details: https://stackoverflow.com/a/27974027/11294572

--- a/yojenkins/utility/utility.py
+++ b/yojenkins/utility/utility.py
@@ -9,7 +9,7 @@ import sysconfig
 import webbrowser
 from pathlib import Path
 from string import Template
-from typing import Dict, List, Tuple, Set, Union
+from typing import Any, Dict, List, Set, Tuple, Union
 from urllib.parse import urljoin, urlparse
 
 import requests
@@ -18,8 +18,6 @@ import xmltodict
 import yaml
 from click import echo, style
 from urllib3.util import parse_url
-
-from typing import Dict, Any
 
 from yojenkins import __version__
 from yojenkins.yo_jenkins.jenkins_item_classes import JenkinsItemClasses
@@ -34,6 +32,7 @@ KWARG_TRANSLATE_MAP = {
     'toml': 'opt_toml',
 }
 
+
 class TextStyle:
     """Text style definitions"""
     HEADER = '\033[95m'
@@ -45,6 +44,7 @@ class TextStyle:
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
     NORMAL = '\033[0m'
+
 
 def translate_kwargs(original_kwargs: Dict[str, Any]) -> Dict[str, Any]:
     """Rename the key names of the provided kwargs based on
@@ -66,6 +66,7 @@ def translate_kwargs(original_kwargs: Dict[str, Any]) -> Dict[str, Any]:
         else:
             new_kwargs[key] = value
     return new_kwargs
+
 
 def print2(message: str, bold: bool = False, color: str = 'reset') -> None:
     """Print a message to the console using click
@@ -114,7 +115,6 @@ def load_contents_from_local_file(file_type: str, local_file_path: str) -> Dict:
     Returns:
         file_contents (dict) : The contents of file
     """
-
     file_type = file_type.lower()
 
     # Check if file exists
@@ -135,12 +135,34 @@ def load_contents_from_local_file(file_type: str, local_file_path: str) -> Dict:
             elif file_type == 'json':
                 file_contents = json.loads(open_file.read())
             else:
-                logger.debug(f"Unknown file type passed: '{file_type}'")
                 raise ValueError(f"Unknown file type passed: '{file_type}'")
         logger.debug(f"Successfully loaded local .{file_type} file")
     except Exception as error:
         fail_out(f"Failed to load specified local .{file_type} file: '{local_file_path}'. Exception: {error}")
     return file_contents
+
+
+def load_contents_from_string(file_type: str, text: str) -> Dict:
+    """Loading a local file contents
+
+    Parameters:
+        file_type (str) : Type of file to be loaded ie. 'yaml', 'toml', 'json'
+        text (str)      : Text string to be loaded as specified filetype
+    Returns:
+        contents (dict) : The contents of file
+    """
+    file_type = file_type.lower()
+    logger.debug(f"Loading specified text string as filetype '{file_type}' ...")
+    if file_type == 'yaml':
+        contents = yaml.safe_load(text)
+    elif file_type == 'toml':
+        contents = toml.loads(text)
+    elif file_type == 'json':
+        contents = json.loads(text)
+    else:
+        raise ValueError(f'Unknown file type passed: "{file_type}"')
+    logger.debug(f'Successfully loaded specified "{file_type}" contents from text string')
+    return contents
 
 
 def load_contents_from_remote_file_url(file_type: str, remote_file_url: str, allow_redirects: bool = True) -> Dict:

--- a/yojenkins/yo_jenkins/build.py
+++ b/yojenkins/yo_jenkins/build.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from itertools import islice
 from time import sleep, time
 from typing import Dict, List, Tuple
+import pprint
 
 import requests
 


### PR DESCRIPTION
## Change Motivation
*(A very brief summary on why you made these changes)*

User can pass entire profile via `--profile` CLI option as a JSON object string
For feature request https://github.com/ismet55555/yojenkins/issues/119

---------------------------------------------
## Describe the Changes Made
*(A very brief summary on what changes you made)*

- This allows user to pass a string text that is a JSON object which defines a profile.
- `--profile` is smart enough to distinguish between a passed profile name or a JSON object as text
- When `yojenkins`realizes that the passed profile is a JSON object as a string, it will not try to load the local credentials file
- If user makes a mistake and messes up JSON object text if will try to hide the output. That is, it will look for the following:
  - Can the string be loaded as JSON?
  - Does the string start with a `{`
- If the passed profile as string is passed and loaded, it will follow the usual validation process of checking for required parameters

## Examples:

```bash
yojenkins server info --profile '{"jenkins_server_url": "http://localhost:8080", "username": "admin", "api_token": "118ca08ec6cca448d1a0a37ba79be31c28"}'
```
```bash
export PROFILE="{"jenkins_server_url": "http://localhost:8080", "username": "admin", "api_token": "118ca08ec6cca448d1a0a37ba79be31c28"}"

yojenkins server info --profile $PROFILE
```


---------------------------------------------
## Change Type
*(Check any that apply)*

- [ ] Bug Fix
- [X] New Feature
- [ ] Code Refactoring
- [ ] Documentation
- [ ] Formatting
- [ ] Automation
- [ ] Unit Tests
- [ ] Other



---------------------------------------------
## How Has This Been Tested?
*(Please describe the tests/commands that you ran to verify your changes)*

Local Jenkins server manual testing


---------------------------------------------
# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
