### PR TITLE
feat: Add show result console logs to build rebuild

### DIFF
--- a/yojenkins/cli_sub_commands/build.py
+++ b/yojenkins/cli_sub_commands/build.py
@@ -195,6 +195,7 @@ def parameters(ctx, debug, **kwargs):
 @click.option('-n', '--number', type=int, required=False, help='Build number')
 @click.option('-u', '--url', type=str, required=False, help='Build URL (No job info needed)')
 @click.option('--latest', type=str, required=False, is_flag=True, help='Latest build (Replaces --number)')
+@click.option('--show-logs', type=bool, required=False, is_flag=True, help='Shows the logs of the new job')
 @click.pass_context
 def rebuild(ctx, debug, **kwargs):
     """Get build parameters


### PR DESCRIPTION
## Change Motivation and Description of Changes Made

One can now type `yojenkins build rebuild XXXX  --latest --show-output`
The job will be recreated, it will busy wait until the job is run and then show the output.

Due to a bug in how yojenkins currently shows the output, I suggest #164 gets merged before this one.

---------------------------------------------
## Change Type
*(Check any that apply)*

- [ ] Bug Fix
- [X] New Feature
- [ ] Code Refactoring
- [ ] Documentation
- [ ] Formatting
- [ ] Automation
- [ ] Unit Tests
- [ ] Other



---------------------------------------------
## How Has This Been Tested?
*(Please describe the tests/commands that you ran to verify your changes)*

Rebuilding jobs and looking at their output!

---------------------------------------------
# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
