### PR TITLE
fix: Change github actions linting

### DIFF
--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -66,7 +66,7 @@ jobs:
         run: pipenv graph
 
       - name: Code Linting
-        run: pipenv run pylint ./yojenkins --rcfile=.pylintrc --fail-under=9.0
+        run: pipenv run pylint ./yojenkins --rcfile=.pylintrc
 
       - name: Build the package
         run: pipenv run python setup.py install --verbose


### PR DESCRIPTION
## Change Motivation
*(A very brief summary on why you made these changes)*

Linting threshold differs from pre-commit and GitHub actions.

---------------------------------------------
## Describe the Changes Made
*(A very brief summary on what changes you made)*

Removed linting threshold from Github actions workflod, relying on `.pylintrc`


---------------------------------------------
## Change Type
*(Check any that apply)*

- [X] Bug Fix
- [ ] New Feature
- [ ] Code Refactoring
- [ ] Documentation
- [ ] Formatting
- [ ] Automation
- [ ] Unit Tests
- [ ] Other
