### PR TITLE
fix: Stream build logs using `progressiveText` endpoint, fall-back on legacy method

### DIFF
--- a/yojenkins/cli_sub_commands/build.py
+++ b/yojenkins/cli_sub_commands/build.py
@@ -121,7 +121,18 @@ def stages(ctx, debug, **kwargs):
               help='Follow/Stream the logs as they are generated')
 @click.pass_context
 def logs(ctx, debug, **kwargs):
-    """Get build logs"""
+    """Get build logs
+
+    EXAMPLES:
+
+    \b
+    - yojenkins build logs "myFolder/myJob" --latest
+    - yojenkins build logs "myFolder/myJob" --latest --tail 10
+    - yojenkins build logs "myFolder/myJob" --latest --tail 0.1
+    - yojenkins build logs "myFolder/myJob" --number 2 --follow
+    - yojenkins build logs "myFolder/myJob" --latest -dd .
+
+    """
     set_debug_log_level(debug)
     if kwargs.get("job") or kwargs.get("url"):
         cli_build.logs(**translate_kwargs(kwargs))

--- a/yojenkins/yo_jenkins/build.py
+++ b/yojenkins/yo_jenkins/build.py
@@ -392,7 +392,7 @@ class Build():
             build_info = self.info(job_name=job_name, job_url=job_url, build_number=build_number, latest=latest)
             url = build_info['url']
 
-        # FIXME: Check if this is an actual build
+        # FIXME: Check if this is an actual build and job/folder/etc
 
         request_url = f"{url.strip('/')}/consoleText"
 
@@ -412,8 +412,8 @@ class Build():
             except Exception as error:
                 fail_out(f'Failed to download or save logs for build. Exception: {error}')
         else:
-            # Stream the logs to console
             if not follow:
+                # Show build logs in console
                 logger.debug('Fetching logs from server ...')
                 return_content, _, return_success = self.rest.request(request_url,
                                                                       'get',
@@ -435,24 +435,78 @@ class Build():
                 logger.debug('Printing out console text logs ...')
                 print2(return_content)
             else:
-                logger.debug('Following/streaming logs from server ...')
-                logger.debug(
-                    'NOTE: Jenkins server does not support requesting partial byte ranges, MUST download entire log to get log message differences'
-                )
-                try:
-                    text_position = 0
-                    while True:
-                        request_url = f"{url.strip('/')}/logText/progressiveText?start={text_position}"
-                        return_content, headers, return_success = self.rest.request(request_url, 'get', is_endpoint=False, json_content=False)
-                        logger.debug(headers)
-                        if len(return_content) != 0:
+                # Stream the logs to console
+                log_poll_interval = 1.0
+                logger.debug(f'Following/streaming logs from server at poll interval: {log_poll_interval}s ...')
+
+                # Check if Jenkins server supports progressiveText
+                _, headers, request_success = self.rest.request(f"{url.strip('/')}/logText/progressiveText?start=0",
+                                                                'head',
+                                                                is_endpoint=False,
+                                                                json_content=False)
+
+                if request_success and "X-Text-Size" in headers:
+                    # Method 1: Fetch logs using progressiveText endpoint
+                    logger.debug('Jenkins server supports requesting partial byte ranges (progressiveText)')
+                    try:
+                        progressive_text_position = headers['X-Text-Size']
+                        while True:
+                            request_url = f"{url.strip('/')}/logText/progressiveText?start={progressive_text_position}"
+                            return_content, headers, _ = self.rest.request(request_url,
+                                                                           'get',
+                                                                           is_endpoint=False,
+                                                                           json_content=False)
+                            logger.debug(f'Request Headers: {headers}')
+                            if len(return_content) != 0:
                                 print2(return_content.strip())
-                        if 'X-More-Data' not in headers:
-                            break
-                        text_position = headers['X-Text-Size']
-                        sleep(10)
-                except KeyboardInterrupt:
-                    logger.debug('Keyboard Interrupt (CTRL-C) by user. Stopping log following ...')
+                            if 'X-More-Data' not in headers:
+                                break
+                            progressive_text_position = headers['X-Text-Size']
+                            sleep(log_poll_interval)
+                    except KeyboardInterrupt:
+                        logger.debug('Keyboard Interrupt (CTRL-C) by user. Stopping log following ...')
+                else:
+                    # Method 2: Fetch logs using log difference (Server does not support progressiveText)
+                    try:
+                        logger.debug(
+                            'Jenkins server does not support requesting partial byte ranges (progressiveText), '
+                            'MUST download entire log to get log message differences')
+                        old_dict = {}
+                        fetch_number = 1
+                        request_url = f"{url.strip('/')}/consoleText"
+                        while True:
+                            headers = self.rest.request(request_url, 'head', is_endpoint=False, json_content=False)[1]
+                            if 'content-length' not in headers:
+                                fail_out(f'Failed to find "content-length" key in server response headers: {headers}')
+                            content_length_sample_1 = int(headers['Content-Length'])
+                            sleep(1)
+                            headers = self.rest.request(request_url, 'head', is_endpoint=False, json_content=False)[1]
+                            content_length_sample_2 = int(headers['Content-Length'])
+
+                            content_length_diff = content_length_sample_2 - content_length_sample_1
+                            if content_length_diff:
+                                logger.debug(
+                                    f'LOG FETCH {fetch_number}: Content length difference: {content_length_diff} bytes'
+                                )
+                                return_content = self.rest.request(request_url,
+                                                                   'get',
+                                                                   is_endpoint=False,
+                                                                   json_content=False)[0]
+                                new_dict = dict.fromkeys(
+                                    list(map(lambda num: num.strip(), return_content.splitlines())))
+
+                                diff = dict.fromkeys(x for x in new_dict if x not in old_dict)
+                                diff_list = list(diff.keys())
+                                diff_text = os.linesep.join(diff_list)
+
+                                old_dict = new_dict
+                                fetch_number += 1
+
+                                print2(diff_text)
+                            else:
+                                logger.debug('No content length difference')
+                    except KeyboardInterrupt:
+                        logger.debug('Keyboard Interrupt (CTRL-C) by user. Stopping log following ...')
         return True
 
     def browser_open(self,

--- a/yojenkins/yo_jenkins/rest.py
+++ b/yojenkins/yo_jenkins/rest.py
@@ -2,7 +2,7 @@
 
 import logging
 from time import perf_counter
-from typing import Dict, Tuple, Union
+from typing import Dict, Literal, Tuple, Union
 
 import requests
 from requests.auth import HTTPBasicAuth
@@ -30,11 +30,11 @@ class Rest:
         # Request session
         if not session:
             logger.debug('Starting new requests session (Type: FuturesSession) ...')
-            self.request_session = FuturesSession(max_workers=16)
+            self.session = FuturesSession(max_workers=16)
         else:
             # Convert to future session
             logger.debug('Converting request session to FutureSession ...')
-            self.request_session = FuturesSession(session=session, max_workers=16)
+            self.session = FuturesSession(session=session, max_workers=16)
 
         # Authentication passed
         self.username: str = username
@@ -78,7 +78,7 @@ class Rest:
         Returns:
             TODO
         """
-        return self.request_session
+        return self.session
 
     def is_reachable(self, server_url: str = '', timeout: int = 5) -> bool:
         """Check if the server is reachable
@@ -112,7 +112,7 @@ class Rest:
 
     def request(self,
                 target: str,
-                request_type: str,
+                request_type: Literal['get', 'post', 'head'],
                 is_endpoint: bool = True,
                 json_content: bool = True,
                 auth: Tuple = None,
@@ -162,49 +162,49 @@ class Rest:
                 auth = HTTPBasicAuth(self.username, self.api_token)
 
         # Use a connection session if possible
-        if not self.request_session or new_session:
+        if not self.session or new_session:
             logger.debug('Starting new requests session')
-            self.request_session = FuturesSession(max_workers=16)
+            self.session = FuturesSession(max_workers=16)
 
         # Making the request
         start_time = perf_counter()
         try:
             if request_type.lower() == 'get':
-                response = self.request_session.get(request_url,
-                                                    params=params,
-                                                    data=data,
-                                                    json=json_data,
-                                                    headers=headers,
-                                                    auth=auth,
-                                                    timeout=timeout,
-                                                    allow_redirects=allow_redirect)
+                response = self.session.get(request_url,
+                                            params=params,
+                                            data=data,
+                                            json=json_data,
+                                            headers=headers,
+                                            auth=auth,
+                                            timeout=timeout,
+                                            allow_redirects=allow_redirect)
             elif request_type.lower() == 'post':
-                response = self.request_session.post(request_url,
-                                                     params=params,
-                                                     data=data,
-                                                     json=json_data,
-                                                     headers=headers,
-                                                     auth=auth,
-                                                     timeout=timeout,
-                                                     allow_redirects=allow_redirect)
+                response = self.session.post(request_url,
+                                             params=params,
+                                             data=data,
+                                             json=json_data,
+                                             headers=headers,
+                                             auth=auth,
+                                             timeout=timeout,
+                                             allow_redirects=allow_redirect)
             elif request_type.lower() == 'head':
-                response = self.request_session.head(request_url,
-                                                     params=params,
-                                                     data=data,
-                                                     json=json_data,
-                                                     headers=headers,
-                                                     auth=auth,
-                                                     timeout=timeout,
-                                                     allow_redirects=allow_redirect)
+                response = self.session.head(request_url,
+                                             params=params,
+                                             data=data,
+                                             json=json_data,
+                                             headers=headers,
+                                             auth=auth,
+                                             timeout=timeout,
+                                             allow_redirects=allow_redirect)
             elif request_type.lower() == 'delete':
-                response = self.request_session.delete(request_url,
-                                                       params=params,
-                                                       data=data,
-                                                       json=json_data,
-                                                       headers=headers,
-                                                       auth=auth,
-                                                       timeout=timeout,
-                                                       allow_redirects=allow_redirect)
+                response = self.session.delete(request_url,
+                                               params=params,
+                                               data=data,
+                                               json=json_data,
+                                               headers=headers,
+                                               auth=auth,
+                                               timeout=timeout,
+                                               allow_redirects=allow_redirect)
             else:
                 logger.debug(f'Request type "{request_type}" not recognized')
                 return {}, {}, False


### PR DESCRIPTION
## Change Motivation
*(A very brief summary on why you made these changes)*

A better, more correct, and less error-prone way of streaming/following Jenkins build logs in the console is using the `progressiveText` API endpoint. However, not all Jenkins servers return the needed headers in order for this endpoint to be used to stream logs to the console.

---------------------------------------------
## Describe the Changes Made
*(A very brief summary on what changes you made)*

- Includes method to utilize `progressiveText` API endpoint to stream/follow build logs
- If `progressiveText` API endpoint does not return the needed information, `yojenkins` will fall back to using the previous method of pulling all logs at intervals and showing the difference.


---------------------------------------------
## Change Type
*(Check any that apply)*

- [X] Bug Fix
- [X] New Feature
- [ ] Code Refactoring
- [ ] Documentation
- [ ] Formatting
- [ ] Automation
- [ ] Unit Tests
- [ ] Other



---------------------------------------------
## How Has This Been Tested?
*(Please describe the tests/commands that you ran to verify your changes)*

- Local Jenkins server, set up with `yojenkins server server-deploy`
- Simple job build with a simple bash script:
   - ```bash
      while :
      do
          currentDatetime=$(date +"%Y-%m-%d %T")
          echo "[$currentDatetime]"
          sleep 3
      done
    ```


---------------------------------------------
# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
