### PR TITLE
fix: yojenkins build parameters --url <URL>

### DIFF
--- a/yojenkins/yo_jenkins/build.py
+++ b/yojenkins/yo_jenkins/build.py
@@ -599,10 +599,10 @@ class Build():
         """
         # TODO: Pass a list of build numbers
         build_url = utility.build_url_complete(build_url)
+        build_info = self.info(build_url, job_name, job_url, build_number, latest)
         if not build_url:
             logger.debug('No build URL passed. Getting build information ...')
             # Get build info request
-            build_info = self.info(build_url, job_name, job_url, build_number, latest)
             build_url = build_info['url']
 
         logger.debug(f'Getting build parameters for: "{build_url}" ...')


### PR DESCRIPTION
## Change Motivation

`yojenkins  build parameters --url  http://MY_JENKINS/job/MY_FOLDER/job/MY_JOB/997/` was broken.

The error was

```
File "/home/mdiez/.local/lib/python3.10/site-packages/yojenkins/yo_jenkins/build.py", line 611, in parameters
    parameter_actions = utility.get_item_action(build_info, 'hudson.model.ParametersAction')
UnboundLocalError: local variable 'build_info' referenced before assignment
```


---------------------------------------------
## Describe the Changes Made
*(A very brief summary on what changes you made)*
I moved where that variable is declared so it's now always available.



---------------------------------------------
## Change Type
*(Check any that apply)*

- [X] Bug Fix
- [ ] New Feature
- [ ] Code Refactoring
- [ ] Documentation
- [ ] Formatting
- [ ] Automation
- [ ] Unit Tests
- [ ] Other



---------------------------------------------
## How Has This Been Tested?
*(Please describe the tests/commands that you ran to verify your changes)*

`yojenkins  build parameters --url  http://MY_JENKINS/job/MY_FOLDER/job/MY_JOB/997/` now works :)

---------------------------------------------
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
