### PR TITLE
feat: `yojenkins build --url <BUILD URL>` can be implied by just `yojenkins build <BUILD URL>`

### DIFF
--- a/yojenkins/cli/cli_build.py
+++ b/yojenkins/cli/cli_build.py
@@ -7,7 +7,7 @@ import click
 
 from yojenkins.cli import cli_utility as cu
 from yojenkins.cli.cli_utility import log_to_history
-from yojenkins.utility.utility import wait_for_build_and_follow_logs
+from yojenkins.utility.utility import wait_for_build_and_follow_logs, is_complete_build_url
 from yojenkins.yo_jenkins.status import Status
 
 # Getting the logger reference
@@ -46,7 +46,10 @@ def info(profile: str, token: str, job: str, number: int, url: str, latest: bool
         url:     The build url to get info on
         latest:  Option to get the latest build
     """
-    if job and not number and not latest:
+    if url is None and job and is_complete_build_url(job):
+        url = job
+        job = None
+    elif job and not number and not latest:
         click.echo(
             click.style('INPUT ERROR: For job, either specify --number or --latest. See --help',
                         fg='bright_red',
@@ -76,7 +79,10 @@ def status(profile: str, token: str, job: str, number: int, url: str, latest: bo
         url: The build url to get info on
         latest: Option to get the latest build
     """
-    if job and not number and not latest:
+    if url is None and job and is_complete_build_url(job):
+        url = job
+        job = None
+    elif job and not number and not latest:
         click.echo(
             click.style('INPUT ERROR: For job, either specify --number or --latest. See --help',
                         fg='bright_red',
@@ -121,7 +127,10 @@ def abort(profile: str, token: str, job: str, number: int, url: str, latest: boo
         url: The build url to get info on
         latest: Option to get the latest build
     """
-    if job and not number and not latest:
+    if url is None and job and is_complete_build_url(job):
+        url = job
+        job = None
+    elif job and not number and not latest:
         click.echo(
             click.style('INPUT ERROR: For job, either specify --number or --latest. See --help',
                         fg='bright_red',
@@ -149,7 +158,10 @@ def delete(profile: str, token: str, job: str, number: int, url: str, latest: bo
         url: The build url to get info on
         latest: Option to get the latest build
     """
-    if job and not number and not latest:
+    if url is None and job and is_complete_build_url(job):
+        url = job
+        job = None
+    elif job and not number and not latest:
         click.echo(
             click.style('INPUT ERROR: For job, either specify --number or --latest. See --help',
                         fg='bright_red',
@@ -178,7 +190,10 @@ def stages(profile: str, token: str, opt_list: bool, job: str, number: int, url:
         url: The build URL
         latest: Option to get the latest build
     """
-    if job and not number and not latest:
+    if url is None and job and is_complete_build_url(job):
+        url = job
+        job = None
+    elif job and not number and not latest:
         click.echo(
             click.style('INPUT ERROR: For job, either specify --number or --latest. See --help',
                         fg='bright_red',
@@ -211,7 +226,10 @@ def logs(profile: str, token: str, job: str, number: int, url: str, latest: bool
         download_dir: Option to download the log to a directory
         follow: Option to follow the log
     """
-    if job and not number and not latest:
+    if url is None and job and is_complete_build_url(job):
+        url = job
+        job = None
+    elif job and not number and not latest:
         click.echo(
             click.style('INPUT ERROR: For job, either specify --number or --latest. See --help',
                         fg='bright_red',
@@ -252,7 +270,10 @@ def browser(profile: str, token: str, job: str, number: int, url: str, latest: b
         url: The build url to get info on
         latest: Option to get the latest build
     """
-    if job and not number and not latest:
+    if url is None and job and is_complete_build_url(job):
+        url = job
+        job = None
+    elif job and not number and not latest:
         click.echo(
             click.style('INPUT ERROR: For job, either specify --number or --latest. See --help',
                         fg='bright_red',
@@ -280,7 +301,10 @@ def monitor(profile: str, token: str, job: str, number: int, url: str, latest: b
         latest: Option to get the latest build
         sound: Option to play a sound when the build status changes
     """
-    if job and not number and not latest:
+    if url is None and job and is_complete_build_url(job):
+        url = job
+        job = None
+    elif job and not number and not latest:
         click.echo(
             click.style('INPUT ERROR: For job, either specify --number or --latest. See --help',
                         fg='bright_red',
@@ -309,7 +333,10 @@ def parameters(profile: str, token: str, opt_list: bool, job: str, number: int, 
         url: The build URL
         latest: Option to get the latest build
     """
-    if job and not number and not latest:
+    if url is None and job and is_complete_build_url(job):
+        url = job
+        job = None
+    elif job and not number and not latest:
         click.echo(
             click.style('INPUT ERROR: For job, either specify --number or --latest. See --help',
                         fg='bright_red',
@@ -339,7 +366,11 @@ def rebuild(profile: str, token: str, job: str, number: int, url: str, latest: b
         latest:  Option to get the latest build
         follow_logs: Waits for the job build, then follows resulting logs
     """
-    if job and not number and not latest:
+
+    if url is None and job and is_complete_build_url(job):
+        url = job
+        job = None
+    elif job and not number and not latest:
         click.echo(
             click.style('INPUT ERROR: For job, either specify --number or --latest. See --help',
                         fg='bright_red',

--- a/yojenkins/cli/cli_build.py
+++ b/yojenkins/cli/cli_build.py
@@ -47,8 +47,7 @@ def info(profile: str, token: str, job: str, number: int, url: str, latest: bool
         latest:  Option to get the latest build
     """
     if url is None and job and is_complete_build_url(job):
-        url = job
-        job = None
+        url, job = job, None
     elif job and not number and not latest:
         click.echo(
             click.style('INPUT ERROR: For job, either specify --number or --latest. See --help',
@@ -80,8 +79,7 @@ def status(profile: str, token: str, job: str, number: int, url: str, latest: bo
         latest: Option to get the latest build
     """
     if url is None and job and is_complete_build_url(job):
-        url = job
-        job = None
+        url, job = job, None
     elif job and not number and not latest:
         click.echo(
             click.style('INPUT ERROR: For job, either specify --number or --latest. See --help',
@@ -128,8 +126,7 @@ def abort(profile: str, token: str, job: str, number: int, url: str, latest: boo
         latest: Option to get the latest build
     """
     if url is None and job and is_complete_build_url(job):
-        url = job
-        job = None
+        url, job = job, None
     elif job and not number and not latest:
         click.echo(
             click.style('INPUT ERROR: For job, either specify --number or --latest. See --help',
@@ -159,8 +156,7 @@ def delete(profile: str, token: str, job: str, number: int, url: str, latest: bo
         latest: Option to get the latest build
     """
     if url is None and job and is_complete_build_url(job):
-        url = job
-        job = None
+        url, job = job, None
     elif job and not number and not latest:
         click.echo(
             click.style('INPUT ERROR: For job, either specify --number or --latest. See --help',
@@ -191,8 +187,7 @@ def stages(profile: str, token: str, opt_list: bool, job: str, number: int, url:
         latest: Option to get the latest build
     """
     if url is None and job and is_complete_build_url(job):
-        url = job
-        job = None
+        url, job = job, None
     elif job and not number and not latest:
         click.echo(
             click.style('INPUT ERROR: For job, either specify --number or --latest. See --help',
@@ -227,8 +222,7 @@ def logs(profile: str, token: str, job: str, number: int, url: str, latest: bool
         follow: Option to follow the log
     """
     if url is None and job and is_complete_build_url(job):
-        url = job
-        job = None
+        url, job = job, None
     elif job and not number and not latest:
         click.echo(
             click.style('INPUT ERROR: For job, either specify --number or --latest. See --help',
@@ -271,8 +265,7 @@ def browser(profile: str, token: str, job: str, number: int, url: str, latest: b
         latest: Option to get the latest build
     """
     if url is None and job and is_complete_build_url(job):
-        url = job
-        job = None
+        url, job = job, None
     elif job and not number and not latest:
         click.echo(
             click.style('INPUT ERROR: For job, either specify --number or --latest. See --help',
@@ -302,8 +295,7 @@ def monitor(profile: str, token: str, job: str, number: int, url: str, latest: b
         sound: Option to play a sound when the build status changes
     """
     if url is None and job and is_complete_build_url(job):
-        url = job
-        job = None
+        url, job = job, None
     elif job and not number and not latest:
         click.echo(
             click.style('INPUT ERROR: For job, either specify --number or --latest. See --help',
@@ -334,8 +326,7 @@ def parameters(profile: str, token: str, opt_list: bool, job: str, number: int, 
         latest: Option to get the latest build
     """
     if url is None and job and is_complete_build_url(job):
-        url = job
-        job = None
+        url, job = job, None
     elif job and not number and not latest:
         click.echo(
             click.style('INPUT ERROR: For job, either specify --number or --latest. See --help',
@@ -368,8 +359,7 @@ def rebuild(profile: str, token: str, job: str, number: int, url: str, latest: b
     """
 
     if url is None and job and is_complete_build_url(job):
-        url = job
-        job = None
+        url, job = job, None
     elif job and not number and not latest:
         click.echo(
             click.style('INPUT ERROR: For job, either specify --number or --latest. See --help',


### PR DESCRIPTION
## Change Motivation

Since I am too lazy to type `--url` all the time, I changed some code so that it autodetects if my job is a URL or not.

That means now one can (but does not need to) omit `--url ` on the following commands:

```
yojenkins build info http://MY_JENKINS/job/MY_FOLDER/job/MY_JOB/997/
yojenkins build status http://MY_JENKINS/job/MY_FOLDER/job/MY_JOB/997/
yojenkins build abort http://MY_JENKINS/job/MY_FOLDER/job/MY_JOB/997/
yojenkins build delete http://MY_JENKINS/job/MY_FOLDER/job/MY_JOB/997/
yojenkins build stages http://MY_JENKINS/job/MY_FOLDER/job/MY_JOB/997/
yojenkins build browser http://MY_JENKINS/job/MY_FOLDER/job/MY_JOB/997/
yojenkins build monitor http://MY_JENKINS/job/MY_FOLDER/job/MY_JOB/997/
yojenkins build parameters http://MY_JENKINS/job/MY_FOLDER/job/MY_JOB/997/
yojenkins build rebuild  http://MY_JENKINS/job/MY_FOLDER/job/MY_JOB/997/
```

---------------------------------------------
## Describe the Changes Made
*(A very brief summary on what changes you made)*


---------------------------------------------
## Change Type
*(Check any that apply)*

- [ ] Bug Fix
- [X] New Feature
- [ ] Code Refactoring
- [ ] Documentation
- [ ] Formatting
- [ ] Automation
- [ ] Unit Tests
- [ ] Other



---------------------------------------------
## How Has This Been Tested?
*(Please describe the tests/commands that you ran to verify your changes)*

Using the commands from the description. That's how I found a bug on `yojenkins build parameters`, which I happend to have fixed here: https://github.com/ismet55555/yojenkins/pull/176


---------------------------------------------
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
