### PR TITLE
fix: Ignore failing Dependabot transitive deps and remove deprecated setup_requires

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
       interval: "daily"
       time: "06:00"
       timezone: "America/New_York"
+    ignore:
+      - dependency-name: "filelock"
+      - dependency-name: "virtualenv"
+      - dependency-name: "wheel"
 #    allow:
 #      # Allow updates for Lodash
 #      - dependency-name: "lodash"

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,6 @@ setuptools.setup(
     long_description=read('README.md'),
     long_description_content_type='text/markdown',
     python_requires='>=3.7',
-    setup_requires=['wheel'],
     py_modules=["yojenkins"],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
## Summary

- Add `ignore` rules in `dependabot.yml` for `filelock`, `virtualenv`, and `wheel` — transitive dependencies that Dependabot's pipenv updater cannot update, causing recurring "The updater encountered one or more errors" failures
- Remove deprecated `setup_requires=['wheel']` from `setup.py` — already superseded by `pyproject.toml`'s `[build-system] requires`

## Root Cause

All recent Actions failures are Dependabot pip updater errors (not CI test failures):

| Package | Failure Dates | Why it fails |
|---------|--------------|--------------|
| `filelock` | Dec 16, Jan 13 | Transitive dep only in `Pipfile.lock` — no manifest entry to bump |
| `virtualenv` | Jan 13 | Transitive dep only in `Pipfile.lock` — no manifest entry to bump |
| `wheel` | Jan 22, Jan 23 | `"*"` wildcard in Pipfile + deprecated `setup_requires` — nothing meaningful to update |

Meanwhile, all `github_actions` updates and all `pull_request` checks pass fine.

## Test plan

- [x] `python setup.py --version` returns `0.1.2` (setup_requires removal is safe)
- [x] YAML validation passes on `dependabot.yml`
- [ ] After merge, Dependabot daily pip runs stop failing for these 3 packages
- [ ] Other pip updates (e.g., `urllib3`) continue working normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>