### PR TITLE
fix: Pass YOJENKINS_TOKEN env var through to auth verify

### DIFF
--- a/tests/test_issue_217.py
+++ b/tests/test_issue_217.py
@@ -1,0 +1,32 @@
+"""Regression test for issue #217: YOJENKINS_TOKEN env var must reach auth verify"""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestAuthVerifyToken:
+    """Verify that the token parameter flows through to create_auth()"""
+
+    @patch('click.secho')
+    @patch('yojenkins.cli.cli_auth.Auth')
+    @patch('yojenkins.cli.cli_auth.Rest')
+    def test_verify_passes_token_to_create_auth(self, mock_rest_cls, mock_auth_cls, mock_secho):
+        from yojenkins.cli import cli_auth
+
+        mock_auth = MagicMock()
+        mock_auth_cls.return_value = mock_auth
+
+        cli_auth.verify(profile='default', token='my-env-token')
+        mock_auth.get_credentials.assert_called_once_with('default')
+        mock_auth.create_auth.assert_called_once_with(token='my-env-token')
+
+    @patch('click.secho')
+    @patch('yojenkins.cli.cli_auth.Auth')
+    @patch('yojenkins.cli.cli_auth.Rest')
+    def test_verify_passes_none_token_when_not_set(self, mock_rest_cls, mock_auth_cls, mock_secho):
+        from yojenkins.cli import cli_auth
+
+        mock_auth = MagicMock()
+        mock_auth_cls.return_value = mock_auth
+
+        cli_auth.verify(profile='default', token=None)
+        mock_auth.create_auth.assert_called_once_with(token=None)

--- a/yojenkins/cli/cli_auth.py
+++ b/yojenkins/cli/cli_auth.py
@@ -77,15 +77,16 @@ def show(**kwargs) -> None:
 
 
 @log_to_history
-def verify(profile: str) -> None:
+def verify(profile: str, token: str) -> None:
     """Check if credentials can authenticate
 
     Args:
         profile: The profile/account to use
+        token:   API token for Jenkins server
     """
     auth = Auth(Rest())
     auth.get_credentials(profile)
-    auth.create_auth()
+    auth.create_auth(token=token)
     click.secho('success', fg='bright_green', bold=True)
 
 

--- a/yojenkins/cli_sub_commands/auth.py
+++ b/yojenkins/cli_sub_commands/auth.py
@@ -91,7 +91,6 @@ def show(debug, **kwargs):
 def verify(debug, **kwargs):
     """Check if current credentials can authenticate with server"""
     set_debug_log_level(debug)
-    del kwargs['token']
     cli_auth.verify(**translate_kwargs(kwargs))
 
 


### PR DESCRIPTION
## Summary
- Removed `del kwargs['token']` in `cli_sub_commands/auth.py` that was discarding the `YOJENKINS_TOKEN` env var value before it reached the handler
- Updated `cli/cli_auth.py` `verify()` to accept `token` param and pass it to `auth.create_auth(token=token)`
- Added regression test verifying the token flows through correctly

## Root Cause
Two-layer bug: Layer 1 deleted the token kwarg, Layer 2 never used it. All other commands (e.g. `server info`) correctly passed the token via `config_yo_jenkins(profile, token)`.

## Test plan
- [ ] Run `export YOJENKINS_TOKEN=<valid_token> && yojenkins auth verify` — should succeed
- [ ] Run `yojenkins auth verify` without env var — should prompt for password as before
- [ ] Run `pytest tests/test_issue_217.py` — regression test passes

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)