### PR TITLE
feat: Skip auth check for browser commands with full URLs

### DIFF
--- a/tests/test_issue_234.py
+++ b/tests/test_issue_234.py
@@ -1,0 +1,25 @@
+"""Test that browser commands skip auth when a full URL is provided (issue #234)"""
+
+from unittest.mock import patch, MagicMock
+
+
+class TestJobBrowserSkipsAuth:
+    @patch('yojenkins.cli.cli_job.browser_open')
+    @patch('yojenkins.cli.cli_job.cu.is_full_url', return_value=True)
+    @patch('yojenkins.cli.cli_job.cu.config_yo_jenkins')
+    def test_job_browser_url_skips_auth(self, mock_config, mock_is_url, mock_browser):
+        from yojenkins.cli import cli_job
+        cli_job.browser(profile=None, token=None, job='http://jenkins/job/foo')
+        mock_browser.assert_called_once_with('http://jenkins/job/foo')
+        mock_config.assert_not_called()
+
+
+class TestFolderBrowserSkipsAuth:
+    @patch('yojenkins.cli.cli_folder.browser_open')
+    @patch('yojenkins.cli.cli_folder.cu.is_full_url', return_value=True)
+    @patch('yojenkins.cli.cli_folder.cu.config_yo_jenkins')
+    def test_folder_browser_url_skips_auth(self, mock_config, mock_is_url, mock_browser):
+        from yojenkins.cli import cli_folder
+        cli_folder.browser(profile=None, token=None, folder='http://jenkins/job/folder1')
+        mock_browser.assert_called_once_with('http://jenkins/job/folder1')
+        mock_config.assert_not_called()

--- a/yojenkins/cli/cli_build.py
+++ b/yojenkins/cli/cli_build.py
@@ -2,6 +2,7 @@
 
 import logging
 import sys
+from webbrowser import open as browser_open
 
 import click
 
@@ -292,6 +293,11 @@ def browser(profile: str, token: str, job: str, number: int, url: str, latest: b
             )
         )
         sys.exit(1)
+
+    # Skip auth when a complete URL is provided and no job resolution needed
+    if url and cu.is_full_url(url) and not job and not number and not latest:
+        browser_open(url)
+        return
 
     yj_obj = cu.config_yo_jenkins(profile, token)
 

--- a/yojenkins/cli/cli_folder.py
+++ b/yojenkins/cli/cli_folder.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import sys
+from webbrowser import open as browser_open
 
 import click
 import xmltodict
@@ -133,11 +134,11 @@ def browser(profile: str, token: str, folder: str) -> None:
     Args:
         TODO
     """
-    yj_obj = cu.config_yo_jenkins(profile, token)
     if cu.is_full_url(folder):
-        yj_obj.folder.browser_open(folder_url=folder)
-    else:
-        yj_obj.folder.browser_open(folder_name=folder)
+        browser_open(folder)
+        return
+    yj_obj = cu.config_yo_jenkins(profile, token)
+    yj_obj.folder.browser_open(folder_name=folder)
 
 
 @log_to_history

--- a/yojenkins/cli/cli_job.py
+++ b/yojenkins/cli/cli_job.py
@@ -4,6 +4,8 @@ import json
 import logging
 import sys
 
+from webbrowser import open as browser_open
+
 import click
 import xmltodict
 
@@ -192,11 +194,11 @@ def browser(profile: str, token: str, job: str) -> None:
     Args:
         TODO
     """
-    yj_obj = cu.config_yo_jenkins(profile, token)
     if cu.is_full_url(job):
-        yj_obj.job.browser_open(job_url=job)
-    else:
-        yj_obj.job.browser_open(job_name=job)
+        browser_open(job)
+        return
+    yj_obj = cu.config_yo_jenkins(profile, token)
+    yj_obj.job.browser_open(job_name=job)
 
 
 @log_to_history


### PR DESCRIPTION
## Summary
- `yojenkins job browser <URL>` no longer prompts for auth when given a full URL
- `yojenkins build browser -u <URL>` same — opens URL directly
- `yojenkins folder browser <URL>` same
- Auth is still required when resolving a job/folder **name** to a URL

## Changes
- `cli/cli_job.py`: Check `is_full_url()` before calling `config_yo_jenkins()`
- `cli/cli_build.py`: Add URL bypass before auth
- `cli/cli_folder.py`: Same pattern
- `tests/test_issue_234.py`: Verify auth is skipped for URL inputs

## Test plan
- [ ] Run `yojenkins job browser http://jenkins.example.com/job/myJob` without any auth configured — should open browser
- [ ] Run `yojenkins job browser myJob` — should still require auth (needed to resolve name)
- [ ] Run `pytest tests/test_issue_234.py`

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)