### PR TITLE
feat: Play sound when pipeline stage is PAUSED_PENDING_INPUT

### DIFF
--- a/tests/test_issue_98.py
+++ b/tests/test_issue_98.py
@@ -1,0 +1,19 @@
+"""Test for issue #98: Sound should play when stage is PAUSED_PENDING_INPUT"""
+
+from yojenkins.yo_jenkins.status import Sound, StageStatus
+
+
+class TestPausedInputSoundConfig:
+    """Verify the sound infrastructure supports PAUSED_INPUT status"""
+
+    def test_paused_input_sound_file_defined(self):
+        """Sound.ITEMS must have a non-empty file for PAUSED_INPUT"""
+        assert Sound.ITEMS.value['PAUSED_INPUT'] != ''
+
+    def test_stage_status_paused_input_value(self):
+        """StageStatus.PAUSED_INPUT must map to the Jenkins API string"""
+        assert StageStatus.PAUSED_INPUT.value == 'PAUSED_PENDING_INPUT'
+
+    def test_paused_input_sound_is_wav(self):
+        """Sound file must be a .wav file"""
+        assert Sound.ITEMS.value['PAUSED_INPUT'].endswith('.wav')

--- a/yojenkins/monitor/build_monitor.py
+++ b/yojenkins/monitor/build_monitor.py
@@ -11,7 +11,7 @@ from time import perf_counter, sleep, time
 
 from yojenkins.monitor.monitor import Monitor
 from yojenkins.utility.utility import get_resource_path
-from yojenkins.yo_jenkins.status import Color, StageStatus, Status
+from yojenkins.yo_jenkins.status import Color, Sound, StageStatus, Status
 
 from . import monitor_utility as mu
 
@@ -61,6 +61,9 @@ class BuildMonitor(Monitor):
         self.message_box_temp_duration = 1  # sec
 
         self.sound_directory = ''
+
+        # Track whether PAUSED_PENDING_INPUT sound has been played for current pause
+        self._stage_paused_sound_played = False
 
     ###########################################################################
     #                         BUILD MONITOR
@@ -297,6 +300,20 @@ class BuildMonitor(Monitor):
 
                     mu.draw_text(scr, result_text.replace('_', ' '), y_row, x_col[3], color=self.color[status_color])
                     y_row += 1
+
+                # Play sound when any stage is stuck in PAUSED_PENDING_INPUT
+                if sound and not self.playing_sound:
+                    has_paused_stage = any(
+                        stage.get('status') == StageStatus.PAUSED_INPUT.value
+                        for stage in self.build_stages_data
+                    )
+                    if has_paused_stage and not self._stage_paused_sound_played:
+                        sound_file = Sound.ITEMS.value['PAUSED_INPUT']
+                        if sound_file:
+                            self.play_sound_thread_on(os.path.join(self.sound_directory, sound_file))
+                            self._stage_paused_sound_played = True
+                    elif not has_paused_stage:
+                        self._stage_paused_sound_played = False
             else:
                 # Change the minimum window height limit (no stages section)
                 self.height_limit = 17


### PR DESCRIPTION
## Summary
- Build monitor now plays a sound when any stage enters `PAUSED_PENDING_INPUT` status
- Uses the existing `PAUSED_INPUT` sound file already defined in `Sound.ITEMS`
- One-shot per pause event — won't repeat every refresh cycle (~0.5s)
- Respects the `--sound` flag and doesn't overlap with build-level sounds

## Design
- `_stage_paused_sound_played` flag tracks whether sound has fired for current pause
- Flag resets when no stages are paused, allowing re-trigger on new pauses
- Check runs inside the existing STAGES section after rendering all stages
- Uses `os.path.join(self.sound_directory, sound_file)` for path construction

## Test plan
- [ ] Run build monitor with `--sound` on a pipeline that has an input stage
- [ ] Verify sound plays when stage shows `PAUSED_PENDING_INPUT`
- [ ] Verify sound does NOT repeat on every screen refresh
- [ ] Verify sound plays again if a NEW stage enters pause
- [ ] Run `pytest tests/test_issue_98.py`

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)