### PR TITLE
fix: Graceful monitor shutdown prevents RuntimeError on quit

### DIFF
--- a/tests/test_issue_218.py
+++ b/tests/test_issue_218.py
@@ -1,0 +1,27 @@
+"""Test for issue #218: Monitor shutdown should not raise RuntimeError"""
+
+from yojenkins.monitor.monitor import Monitor
+
+
+class TestMonitorGracefulShutdown:
+    def test_all_threads_off_sets_flag(self):
+        m = Monitor()
+        m.all_threads_enabled = True
+        m.all_threads_off()
+        assert m.all_threads_enabled is False
+
+    def test_threads_list_initialized(self):
+        m = Monitor()
+        assert hasattr(m, '_threads')
+        assert m._threads == []
+
+    def test_all_threads_off_clears_thread_list(self):
+        m = Monitor()
+        m._threads = ['fake_thread']
+        # Mock thread with join
+        class FakeThread:
+            def join(self, timeout=None):
+                pass
+        m._threads = [FakeThread()]
+        m.all_threads_off()
+        assert m._threads == []

--- a/yojenkins/monitor/build_monitor.py
+++ b/yojenkins/monitor/build_monitor.py
@@ -422,7 +422,7 @@ class BuildMonitor(Monitor):
             # Show the build logs
             if self.build_logs:
                 self.help = False
-                self.all_threads_enabled = False
+                self.all_threads_off()
                 curses.echo(True)
                 curses.nl(True)
                 curses.endwin()
@@ -439,7 +439,7 @@ class BuildMonitor(Monitor):
                 mu.draw_message_box(scr, message_lines)
                 # Quit Message confirmed (pressed twice)
                 if self.quit > 1:
-                    self.all_threads_enabled = False
+                    self.all_threads_off()
                     return True
             else:
                 halfdelay_normal = True
@@ -450,7 +450,7 @@ class BuildMonitor(Monitor):
 
             # Straight exist program
             if self.exit:
-                self.all_threads_enabled = False
+                self.all_threads_off()
                 sys.exit(0)
 
             ########################################################################################
@@ -505,8 +505,11 @@ class BuildMonitor(Monitor):
         while self.all_threads_enabled:
             if not self.paused:
                 self.server_interaction = True
-                with self._build_info_thread_lock:
-                    self.build_info_data = self.build.info(build_url=build_url)
+                try:
+                    with self._build_info_thread_lock:
+                        self.build_info_data = self.build.info(build_url=build_url)
+                except RuntimeError:
+                    break
 
             # Wait some time before checking again
             start_time = time()
@@ -530,14 +533,16 @@ class BuildMonitor(Monitor):
         """
         logger.debug(f'Starting thread for build info for "{build_url}" ...')
         try:
-            threading.Thread(
+            t = threading.Thread(
                 target=self.__thread_build_info,
                 args=(
                     build_url,
                     monitor_interval,
                 ),
-                daemon=False,
-            ).start()
+                daemon=True,
+            )
+            t.start()
+            self._threads.append(t)
         except Exception as error:
             logger.error(
                 f'Failed to start build info monitoring thread for {build_url}. Exception: {error}. Type: {type(error)}'
@@ -578,8 +583,11 @@ class BuildMonitor(Monitor):
         while self.all_threads_enabled:
             if not self.paused:
                 self.server_interaction = True
-                with self._build_stages_thread_lock:
-                    self.build_stages_data = self.build.stage_list(build_url=build_url)[0]
+                try:
+                    with self._build_stages_thread_lock:
+                        self.build_stages_data = self.build.stage_list(build_url=build_url)[0]
+                except RuntimeError:
+                    break
 
             # Wait some time before checking again
             start_time = time()
@@ -603,14 +611,16 @@ class BuildMonitor(Monitor):
         """
         logger.debug(f'Starting thread for build stages for "{build_url}" ...')
         try:
-            threading.Thread(
+            t = threading.Thread(
                 target=self.__thread_build_stages,
                 args=(
                     build_url,
                     monitor_interval,
                 ),
-                daemon=False,
-            ).start()
+                daemon=True,
+            )
+            t.start()
+            self._threads.append(t)
         except Exception as error:
             logger.error(
                 f'Failed to start build info monitoring thread for {build_url}. Exception: {error}. Type: {type(error)}'

--- a/yojenkins/monitor/job_monitor.py
+++ b/yojenkins/monitor/job_monitor.py
@@ -328,7 +328,7 @@ class JobMonitor(Monitor):
                 mu.draw_message_box(scr, message_lines)
                 # Quit Message confirmed (pressed twice)
                 if self.quit > 1:
-                    self.all_threads_enabled = False
+                    self.all_threads_off()
                     return True
             else:
                 halfdelay_normal = True
@@ -339,7 +339,7 @@ class JobMonitor(Monitor):
 
             # Straight exist program
             if self.exit:
-                self.all_threads_enabled = False
+                self.all_threads_off()
                 sys.exit(0)
 
             ########################################################################################
@@ -532,7 +532,9 @@ class JobMonitor(Monitor):
         """
         logger.debug('Starting thread for job builds info ...')
         try:
-            threading.Thread(target=self.__thread_builds_data, args=(monitor_interval,), daemon=False).start()
+            t = threading.Thread(target=self.__thread_builds_data, args=(monitor_interval,), daemon=True)
+            t.start()
+            self._threads.append(t)
         except Exception as error:
             logger.error(f'Failed to start job builds info monitoring thread. Exception: {error}. Type: {type(error)}')
 

--- a/yojenkins/monitor/monitor.py
+++ b/yojenkins/monitor/monitor.py
@@ -62,6 +62,7 @@ class Monitor:
 
         self.all_threads_enabled = True
         self.paused = False
+        self._threads: list = []
 
         self.server_interaction = False
 
@@ -275,8 +276,12 @@ class Monitor:
             if not self.paused:
                 # Get the build information
                 self.server_interaction = True
-                self.server_status_data['reachable'] = self.rest.is_reachable()
-                self.server_status_data['auth'] = self.auth.verify()
+                try:
+                    self.server_status_data['reachable'] = self.rest.is_reachable()
+                    self.server_status_data['auth'] = self.auth.verify()
+                except RuntimeError:
+                    # Session executor shut down during quit — exit gracefully
+                    break
 
             # Wait some time before checking again
             start_time = time()
@@ -298,7 +303,9 @@ class Monitor:
         """
         logger.debug('Starting thread for server status ...')
         try:
-            threading.Thread(target=self.__thread_server_status, args=(monitor_interval,), daemon=False).start()
+            t = threading.Thread(target=self.__thread_server_status, args=(monitor_interval,), daemon=True)
+            t.start()
+            self._threads.append(t)
         except Exception as error:
             logger.error(f'Failed to start server status monitoring thread. Exception: {error}. Type: {type(error)}')
             return False
@@ -309,19 +316,22 @@ class Monitor:
     #                         ALL THREAD CONTROL
     ###########################################################################
 
-    def all_threads_off(self) -> bool:
+    def all_threads_off(self, timeout: float = 2.0) -> bool:
         """Stop all independent threads running in the background
 
         Args:
-            None
+            timeout: Maximum seconds to wait for each thread to finish
 
         Returns:
             True
         """
-        # logger.debug(f'Stopping all monitor threads ...')
-
         # Set the monitoring thread flag down
         self.all_threads_enabled = False
+
+        # Wait for threads to exit gracefully
+        for t in self._threads:
+            t.join(timeout=timeout)
+        self._threads.clear()
 
         return True
 


### PR DESCRIPTION
## Summary
- Fixed race condition where background threads attempted HTTP requests after the FuturesSession executor was shut down during monitor quit
- All monitor threads now catch `RuntimeError` and exit gracefully
- Changed threads to `daemon=True` with tracked references for orderly shutdown
- `all_threads_off()` now joins threads with a 2-second timeout

## Root Cause
When pressing `q` twice, `build_monitor.py` set `self.all_threads_enabled = False` and returned immediately. Background threads (server status, build info, build stages) were still mid-HTTP-request when Python's garbage collector shut down the `FuturesSession`'s `ThreadPoolExecutor`, causing `RuntimeError: cannot schedule new futures after shutdown`.

## Files Changed
| File | Changes |
|------|---------|
| `monitor/monitor.py` | Thread tracking, RuntimeError catch, join in `all_threads_off()` |
| `monitor/build_monitor.py` | RuntimeError catch in data threads, daemon threads, use `all_threads_off()` |
| `monitor/job_monitor.py` | Daemon threads, use `all_threads_off()` |

## Test plan
- [ ] Run `yojenkins build monitor --latest --sound <job>`, press q twice — no RuntimeError
- [ ] Run `pytest tests/test_issue_218.py`

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)