### PR TITLE
fix: Resolve circular import and Docker container bugs

### DIFF
--- a/yojenkins/docker_container/docker_jenkins_server.py
+++ b/yojenkins/docker_container/docker_jenkins_server.py
@@ -14,7 +14,7 @@ from time import perf_counter
 from typing import Any
 
 import docker
-from docker.errors import DockerException
+from docker.errors import DockerException, ImageNotFound
 
 from yojenkins.utility.utility import fail_out, get_resource_path, print2
 
@@ -231,7 +231,7 @@ class DockerJenkinsServer:
         logger.debug(f'Dockerfile context directory: {self.image_dockerfile_dir}')
         try:
             _, build_logs = self.docker_client.images.build(
-                path=self.image_dockerfile_dir,
+                path=str(self.image_dockerfile_dir),
                 tag=self.image_fullname,
                 rm=True,
                 buildargs=self.image_build_args,
@@ -284,6 +284,9 @@ class DockerJenkinsServer:
         logger.debug(f'Removing image: {self.image_fullname} ...')
         try:
             self.docker_client.images.remove(self.image_fullname)
+        except ImageNotFound:
+            logger.debug(f'Image not found (nothing to remove): {self.image_fullname}')
+            return True
         except DockerException as error:
             logger.debug(f'Failed to remove image: {self.image_fullname}. Exception: {error}')
             return False
@@ -372,11 +375,14 @@ class DockerJenkinsServer:
         Returns:
             TODO
         """
-        # Getting docker group id (Unix only)
+        # Getting docker group id (Unix only, may not exist on macOS with Docker Desktop)
+        docker_gid = None
         if platform.system() != 'Windows':
-            docker_gid = [getgrnam('docker').gr_gid]
-        else:
-            docker_gid = None
+            try:
+                docker_gid = [getgrnam('docker').gr_gid]
+            except KeyError:
+                logger.debug('Docker group not found (common on macOS with Docker Desktop)')
+                docker_gid = None
 
         logger.debug(f'Local docker service group id found: {docker_gid}')
 

--- a/yojenkins/utility/utility.py
+++ b/yojenkins/utility/utility.py
@@ -23,8 +23,6 @@ from urllib3.util import parse_url
 from yaspin import yaspin
 from yaspin.spinners import Spinners
 
-from yojenkins.yo_jenkins.jenkins_item_classes import JenkinsItemClasses
-
 logger = logging.getLogger()
 
 CONFIG_DIR_NAME = '.yojenkins'
@@ -842,6 +840,8 @@ def queue_find(all_queue_info: dict, job_name: str = '', job_url: str = '', firs
         return []
     job_name = job_name if job_name else url_to_name(job_url)
 
+    from yojenkins.yo_jenkins.jenkins_item_classes import JenkinsItemClasses  # noqa: PLC0415, I001 — deferred to avoid circular import
+
     queue_item_matches = []
 
     for i, queue_item in enumerate(all_queue_info['items']):
@@ -959,6 +959,8 @@ def item_exists_in_folder(item_name: str, folder_url: str, item_type: str, rest:
     Returns:
         True if the item exists, False if not
     """
+    from yojenkins.yo_jenkins.jenkins_item_classes import JenkinsItemClasses  # noqa: PLC0415, I001 — deferred to avoid circular import
+
     item_type_info = getattr(JenkinsItemClasses, item_type.upper())
     prefix = item_type_info.value['prefix']
 


### PR DESCRIPTION
## Summary
- **Circular import fix**: Defer `JenkinsItemClasses` import from module-level to function scope in `utility.py` (`queue_find()` and `item_exists_in_folder()`), breaking the `utility → yo_jenkins → utility` import cycle
- **Docker `ImageNotFound` handling**: `_image_remove()` now handles `ImageNotFound` gracefully for idempotent cleanup
- **Docker `PosixPath` fix**: Cast `self.image_dockerfile_dir` to `str` in `_image_build()` for Docker SDK compatibility
- **macOS Docker group fix**: `_container_run()` catches `KeyError` when the `docker` Unix group doesn't exist (common on macOS with Docker Desktop)

## Files changed
- `yojenkins/utility/utility.py` (+4, -2)
- `yojenkins/docker_container/docker_jenkins_server.py` (+12, -6)

## Test plan
- [x] Ruff lint passes on both files
- [x] Import smoke test: `from yojenkins.utility.utility import queue_find, item_exists_in_folder` succeeds without `ImportError`
- [ ] Existing unit tests pass (`pytest -m "not docker"`)
- [ ] Docker integration tests pass on macOS and Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)